### PR TITLE
Add rails 3 support

### DIFF
--- a/lib/preload_counts/ar.rb
+++ b/lib/preload_counts/ar.rb
@@ -56,7 +56,11 @@ module PreloadCounts
       conditions = []
 
       if scope
-        scope_sql = resolved_association.send(scope).to_sql
+        if ActiveRecord::VERSION::MAJOR < 3
+          scope_sql = resolved_association.scopes[scope].call(resolved_association).send(:construct_finder_sql, {})
+        else
+          scope_sql = resolved_association.send(scope).to_sql
+        end
         condition = scope_sql.gsub(/^.*WHERE/, '')
         conditions << condition
       end

--- a/preload_counts.gemspec
+++ b/preload_counts.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rspec"
   s.add_development_dependency "activerecord", "~> 3.2.0"
+  #s.add_development_dependency "rails", "~> 2.3.12"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "ruby-debug"
   s.add_development_dependency "multi_rails"

--- a/spec/active_record_spec.rb
+++ b/spec/active_record_spec.rb
@@ -1,8 +1,12 @@
 require 'spec_helper'
 require 'logger'
 
-ActiveRecord::Base.establish_connection(:adapter => "sqlite3", :database => ":memory:")
-ActiveRecord::Base.logger = Logger.new(nil)
+if ActiveRecord::VERSION::MAJOR < 3
+  ActiveRecord::Base.establish_connection(:adapter => "sqlite3", :dbfile => ":memory:")
+else
+  ActiveRecord::Base.establish_connection(:adapter => "sqlite3", :database => ":memory:")
+  ActiveRecord::Base.logger = Logger.new(nil)
+end
 
 def setup_db
   ActiveRecord::Schema.define(:version => 1) do
@@ -35,7 +39,11 @@ end
 class Comment < ActiveRecord::Base
   belongs_to :post
 
-  scope :with_even_id, where('id % 2 = 0')
+  if ActiveRecord::VERSION::MAJOR < 3
+    named_scope :with_even_id, lambda { {:conditions => "comments.id % 2 == 0"} }
+  else
+    scope :with_even_id, where('id % 2 = 0')
+  end
 end
 
 def create_data


### PR DESCRIPTION
This fix will add Rails 3 support alongside Rails 2 support. It uses ActiveRecord::VERSION::MAJOR to distinguish between both implementation.
