### PR TITLE
Make compatible with Rails 3.2.22

### DIFF
--- a/lib/preload_counts/ar.rb
+++ b/lib/preload_counts/ar.rb
@@ -28,7 +28,7 @@ module PreloadCounts
         singleton.send :define_method, name do
           sql = ["#{table_name}.*"] + scopes_to_select(association, scopes)
           sql = sql.join(', ')
-          all.select(sql)
+          scoped.select(sql)
         end
 
         scopes.each do |scope|
@@ -61,9 +61,12 @@ module PreloadCounts
         conditions << condition
       end
 
-      r_scope = self.reflections.with_indifferent_access[association].scope
-      if r_scope
-        conditions += self.instance_eval(&r_scope).where_values
+      reflection = self.reflections.with_indifferent_access[association]
+      if reflection.respond_to?(:scope)
+        r_scope = reflection.scope
+        if r_scope
+          conditions += self.instance_eval(&r_scope).where_values
+        end
       end
 
       sql = <<-SQL


### PR DESCRIPTION
We are using preload_counts in rails 3.2.22 project.

Sadly it was not working because of two issues:
- `all` is not lazy and so its not possible to call `all.scoped`. switch to `scoped` instead
- the association reflection has no method `scope`. check with `respond_to?` before calling

I have not checked these changes with rails 4.
